### PR TITLE
Update README to remove Early Access note

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Adds a feed layout to [Obsidian Bases](https://help.obsidian.md/bases) so you ca
 
 This plugin currently requires Obsidian v1.10.0 or later to work.
 
-Obsidian v1.10.0 is currently in [Early Access](https://help.obsidian.md/early-access), so you will need a [Catalyst license](https://help.obsidian.md/catalyst) to use it.
-
 ### Install via BRAT
 
 1. Install the [BRAT plugin](obsidian://show-plugin?id=obsidian42-brat) under Community Plugins.


### PR DESCRIPTION
Removed information about the Early Access requirement for Obsidian v1.10.0.

Now that 1.10.0 is out in public you don't need that note.

PS: Any update on the plugin review process? Can we track that somewhere?